### PR TITLE
Add .externalNativeBuild to Android gitignore

### DIFF
--- a/Android.gitignore
+++ b/Android.gitignore
@@ -39,3 +39,6 @@ captures/
 
 # Keystore files
 *.jks
+
+# External native build folder generated in Android Studio 2.2 and later
+.externalNativeBuild


### PR DESCRIPTION
**Reasons for making this change:**

As of Android Studio 2.2 Preview 6, the default .gitignore generated for a project includes this file.

**Links to documentation supporting these rule changes:** 

https://sites.google.com/a/android.com/tools/tech-docs/external-c-builds#TOC-Release-History
